### PR TITLE
✨ Use `Sendable` wrapper for handling side effect

### DIFF
--- a/Examples/DripperDemo/DripperDemo/Counter.swift
+++ b/Examples/DripperDemo/DripperDemo/Counter.swift
@@ -40,17 +40,18 @@ struct Counter: Dripper {
             case .resetCounter:
                 state.counter = .zero
             case .randomNumber:
-                return .init { _ in
+                return .run { pour in
                     func randomNumber() async throws -> Int {
-                        try await Task.sleep(for: .seconds(2))
+                        try await Task.sleep(for: .seconds(1))
                         return Int.random(in: 0...10)
                     }
                     let randomNumber = try await randomNumber()
+                    await pour(.decreaseCounter)
                     state.counter = randomNumber
                 }
             }
 
-            return .init { _ in }
+            return .none
         }
     }
 }

--- a/Sources/Dripper/Drip.swift
+++ b/Sources/Dripper/Drip.swift
@@ -11,7 +11,7 @@ public struct Drip<State: Observable, Action>: Dripper {
 
     // MARK: Properties
 
-    @usableFromInline let drip: (State, Action) -> Effect<Action>
+    @usableFromInline let drip: (State, Action) -> Effect<Action>?
 
     // MARK: Lifecycle
 
@@ -25,14 +25,14 @@ public struct Drip<State: Observable, Action>: Dripper {
     }
 
     @usableFromInline
-    init(internal drip: @escaping (_ state: State, _ action: Action) -> Effect<Action>) {
+    init(internal drip: @escaping (_ state: State, _ action: Action) -> Effect<Action>?) {
         self.drip = drip
     }
 
     // MARK: Functions
 
     @inlinable
-    public func drip(_ state: State, _ action: Action) -> Effect<Action> {
+    public func drip(_ state: State, _ action: Action) -> Effect<Action>? {
         drip(state, action)
     }
 }

--- a/Sources/Dripper/Dripper.swift
+++ b/Sources/Dripper/Dripper.swift
@@ -16,7 +16,7 @@ public protocol Dripper<State, Action> {
     associatedtype Action
     associatedtype Body
 
-    func drip(_ state: State, _ action: Action) -> Effect<Action>
+    func drip(_ state: State, _ action: Action) -> Effect<Action>?
 
     @DripperBuilder<State, Action>
     var body: Body { get }
@@ -30,7 +30,7 @@ extension Dripper where Body == Never {
 
 extension Dripper where Body: Dripper<State, Action> {
     @inlinable
-    public func drip(_ state: Body.State, _ action: Body.Action) -> Effect<Action> {
+    public func drip(_ state: Body.State, _ action: Body.Action) -> Effect<Action>? {
         body.drip(state, action)
     }
 }

--- a/Sources/Dripper/Effect.swift
+++ b/Sources/Dripper/Effect.swift
@@ -6,13 +6,68 @@
 //
 
 import Foundation
+import OSLog
+
+// MARK: - Effect
 
 public struct Effect<Action> {
-    public typealias ActionHandler = @MainActor @Sendable (Action) -> Void
+    public typealias Kettle = @Sendable (_ blend: Pour<Action>) async -> Void
 
-    public let run: (_ action: ActionHandler) async throws -> Void
+    @usableFromInline let kettle: Kettle
 
-    public init(run: @escaping (_ action: ActionHandler) async throws -> Void) {
-        self.run = run
+    @usableFromInline
+    init(kettle: @escaping Kettle) {
+        self.kettle = kettle
+    }
+}
+
+// MARK: - Pour
+
+@MainActor
+public struct Pour<Action>: Sendable {
+    let pour: @MainActor @Sendable (Action) -> Void
+
+    init(pour: @escaping @MainActor @Sendable (Action) -> Void) {
+        self.pour = pour
+    }
+
+    public func callAsFunction(_ action: Action) {
+        pour(action)
+    }
+}
+
+extension Effect {
+
+    // MARK: Static Computed Properties
+
+    public static var none: Self {
+        Self { _ in }
+    }
+
+    // MARK: Static Functions
+
+    public static func run(
+        kettle: @escaping @Sendable (_ pour: Pour<Action>) async throws -> Void,
+        catch errorHandler: (@Sendable (_ error: any Error, _ pour: Pour<Action>) async -> Void)? = nil,
+        fileID: StaticString = #fileID,
+        line: UInt = #line
+    ) -> Self {
+        Self { pour in
+            do {
+                try await kettle(pour)
+            } catch {
+                guard let errorHandler else {
+                    os_log(
+                        .fault,
+                        """
+                        An "Effect.run" returned from "\(fileID):\(line)" threw an unhandled error.
+                        This error must be handled via the `catch` parameter.
+                        """
+                    )
+                    return
+                }
+                await errorHandler(error, pour)
+            }
+        }
     }
 }

--- a/Sources/Dripper/Station.swift
+++ b/Sources/Dripper/Station.swift
@@ -49,10 +49,12 @@ public final class Station<State: Observable, Action> {
 
     public func pour(_ action: Action) {
         let effect = dripper.drip(state, action)
-        // FIXME: Currently, side effect is called no matter it's empty or not.
-        Task {
-            try await effect.run { action in
-                pour(action)
+
+        if let effect {
+            Task {
+                await effect.kettle(
+                    Pour { self.pour($0) }
+                )
             }
         }
     }


### PR DESCRIPTION
- Use `Sendable` wrapped struct `Pour` to handle side effects.

```swift
// Usage
var body: some Dripper<State, Action> {
    Drip { state, action in
        switch action {
        case .randomNumber:
            return .run { pour in // 🙋‍♂️
                func randomNumber() async throws -> Int {
                    try await Task.sleep(for: .seconds(1))
                    return Int.random(in: 0...10)
                }
                let randomNumber = try await randomNumber()
                await pour(.decreaseCounter)
                state.counter = randomNumber
            }
        }
        return .none
    }
}
```